### PR TITLE
Add missing simulations for Normal Distribution and Metropolis–Hastings

### DIFF
--- a/src/components/ConceptSimulationWrapper.tsx
+++ b/src/components/ConceptSimulationWrapper.tsx
@@ -11,6 +11,7 @@ import BayesianInferenceSimulation from '@/components/BayesianInferenceSimulatio
 import ABTestingSimulation from '@/components/ABTestingSimulation';
 import MCMCSimulation from '@/components/MCMCSimulation';
 import StandardDeviationSimulation from '@/components/StandardDeviationSimulation';
+import NormalDistributionSimulation from '@/components/NormalDistributionSimulation';
 import PValueSimulation from '@/components/PValueSimulation';
 import TypeErrorsSimulation from '@/components/TypeErrorsSimulation';
 import LawOfLargeNumbersSimulation from '@/components/LawOfLargeNumbersSimulation';
@@ -73,6 +74,7 @@ import DataCleansingSimulation from './DataCleansingSimulation';
 import ETLSimulation from './ETLSimulation';
 import BayesianNetworkSimulation from './BayesianNetworkSimulation';
 import GibbsSamplingSimulation from './GibbsSamplingSimulation';
+import MetropolisHastingsAlgorithmSimulation from './MetropolisHastingsAlgorithmSimulation';
 import HiddenMarkovModelSimulation from './HiddenMarkovModelSimulation';
 import KalmanFilterSimulation from './KalmanFilterSimulation';
 import AutoregressiveModelSimulation from './AutoregressiveModelSimulation';
@@ -127,6 +129,7 @@ const simulationMap: Record<string, React.ComponentType> = {
     'ab-testing': ABTestingSimulation,
     'mcmc-methods': MCMCSimulation,
     'monte-carlo-simulation': MCMCSimulation,
+    'normal-distribution': NormalDistributionSimulation,
     'standard-deviation': StandardDeviationSimulation,
     'anova': AnovaSimulation,
     'chi-squared-test': ChiSquaredTestSimulation,
@@ -208,6 +211,7 @@ const simulationMap: Record<string, React.ComponentType> = {
     'bayesian-networks': BayesianNetworkSimulation,
     'mcmc': MCMCSimulation,
     'gibbs-sampling': GibbsSamplingSimulation,
+    'metropolis-hastings-algorithm': MetropolisHastingsAlgorithmSimulation,
     'hidden-markov-model': HiddenMarkovModelSimulation,
     'kalman-filter': KalmanFilterSimulation,
     'autoregressive-model': AutoregressiveModelSimulation,

--- a/src/components/MetropolisHastingsAlgorithmSimulation.tsx
+++ b/src/components/MetropolisHastingsAlgorithmSimulation.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { Shuffle } from 'lucide-react';
+
+// Target distribution: mixture of two bivariate normals
+const targetPDF = (x: number, y: number): number => {
+    const term1 = Math.exp(-0.5 * (((x - 2) ** 2) / 1 + ((y - 2) ** 2) / 1));
+    const term2 = Math.exp(-0.5 * (((x + 2) ** 2) / 1 + ((y + 2) ** 2) / 1));
+    return term1 + term2;
+};
+
+// Standard normal proposal using Box-Muller
+const randomNormal = () => {
+    let u1 = 0, u2 = 0;
+    while (u1 === 0) u1 = Math.random();
+    while (u2 === 0) u2 = Math.random();
+    return Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+};
+
+interface Sample { x: number; y: number; }
+
+const MetropolisHastingsAlgorithmSimulation = () => {
+    const [samples, setSamples] = useState<Sample[]>([]);
+    const [steps, setSteps] = useState(1000);
+    const [isSimulating, setIsSimulating] = useState(false);
+
+    const runSimulation = useCallback(() => {
+        setIsSimulating(true);
+        setTimeout(() => {
+            let current: Sample = samples.length > 0 ? samples[samples.length - 1] : { x: 0, y: 0 };
+            const proposalStdDev = 1.0;
+            const newSamples: Sample[] = [];
+            for (let i = 0; i < steps; i++) {
+                const proposal = {
+                    x: current.x + randomNormal() * proposalStdDev,
+                    y: current.y + randomNormal() * proposalStdDev,
+                };
+                const acceptProb = Math.min(1, targetPDF(proposal.x, proposal.y) / targetPDF(current.x, current.y));
+                if (Math.random() < acceptProb) {
+                    current = proposal;
+                }
+                newSamples.push(current);
+            }
+            setSamples(prev => [...prev, ...newSamples].slice(-5000));
+            setIsSimulating(false);
+        }, 10);
+    }, [steps, samples]);
+
+    const reset = () => setSamples([]);
+
+    return (
+        <Card className="overflow-hidden">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2"><Shuffle /> Metropolis-Hastings</CardTitle>
+                <CardDescription>Sample from a complex distribution using the Metropolis-Hastings algorithm.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="lg:col-span-1 space-y-4">
+                    <div>
+                        <label className="font-semibold">Steps: {steps}</label>
+                        <Slider value={[steps]} onValueChange={v => setSteps(v[0])} min={100} max={5000} step={100} />
+                    </div>
+                    <Button onClick={runSimulation} disabled={isSimulating} className="w-full">
+                        {isSimulating ? 'Running...' : 'Run Simulation'}
+                    </Button>
+                    <Button variant="outline" onClick={reset} className="w-full">Clear Samples</Button>
+                    <Card className="text-center">
+                        <CardHeader>
+                            <CardTitle>Total Samples</CardTitle>
+                            <CardDescription className="text-2xl font-bold">{samples.length}</CardDescription>
+                        </CardHeader>
+                    </Card>
+                </div>
+                <div className="lg:col-span-2 min-h-[400px]">
+                    <ResponsiveContainer width="100%" height={400}>
+                        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+                            <CartesianGrid />
+                            <XAxis type="number" dataKey="x" name="X" domain={[-6, 6]} />
+                            <YAxis type="number" dataKey="y" name="Y" domain={[-6, 6]} />
+                            <Scatter data={samples} fill="hsl(var(--primary))" shape="circle" fillOpacity={0.3} stroke="none" />
+                        </ScatterChart>
+                    </ResponsiveContainer>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+
+export default MetropolisHastingsAlgorithmSimulation;

--- a/src/components/NormalDistributionSimulation.tsx
+++ b/src/components/NormalDistributionSimulation.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Slider } from '@/components/ui/slider';
+import { Button } from '@/components/ui/button';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, Label } from 'recharts';
+import { Dice5 } from 'lucide-react';
+
+// Generate normal random variable using Box-Muller transform
+function randomNormal(mean: number, stdDev: number) {
+    let u = 0, v = 0;
+    while(u === 0) u = Math.random();
+    while(v === 0) v = Math.random();
+    const z = Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+    return z * stdDev + mean;
+}
+
+const NormalDistributionSimulation = () => {
+    const [mean, setMean] = useState(0);
+    const [stdDev, setStdDev] = useState(1);
+    const [sample, setSample] = useState<number[]>([]);
+
+    const generateSample = () => {
+        const newSample = Array.from({ length: 500 }, () => randomNormal(mean, stdDev));
+        setSample(newSample);
+    };
+
+    const histogramData = useMemo(() => {
+        if (sample.length === 0) return [];
+        const binWidth = stdDev / 2;
+        const min = Math.floor(Math.min(...sample) / binWidth) * binWidth;
+        const max = Math.ceil(Math.max(...sample) / binWidth) * binWidth;
+        const bins = new Map<number, number>();
+        for (let x = min; x <= max; x += binWidth) {
+            bins.set(Number(x.toFixed(2)), 0);
+        }
+        sample.forEach(v => {
+            const bin = Math.floor(v / binWidth) * binWidth;
+            const key = Number(bin.toFixed(2));
+            bins.set(key, (bins.get(key) || 0) + 1);
+        });
+        return Array.from(bins.entries()).map(([x, count]) => ({ x, count }));
+    }, [sample, stdDev]);
+
+    return (
+        <Card className="overflow-hidden">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2"><Dice5 /> Normal Distribution</CardTitle>
+                <CardDescription>Generate random samples from a normal distribution and visualize their histogram.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="space-y-4 lg:col-span-1">
+                    <div>
+                        <label className="font-semibold">Mean: {mean.toFixed(1)}</label>
+                        <Slider value={[mean]} onValueChange={([v]) => setMean(v)} min={-5} max={5} step={0.1} />
+                    </div>
+                    <div>
+                        <label className="font-semibold">Std. Dev.: {stdDev.toFixed(1)}</label>
+                        <Slider value={[stdDev]} onValueChange={([v]) => setStdDev(v)} min={0.5} max={5} step={0.1} />
+                    </div>
+                    <Button onClick={generateSample} className="w-full">Generate Sample</Button>
+                </div>
+                <div className="lg:col-span-2 min-h-[400px]">
+                    <ResponsiveContainer width="100%" height={400}>
+                        <BarChart data={histogramData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="x" name="Value" type="number" />
+                            <YAxis allowDecimals={false} />
+                            <Tooltip cursor={{ fill: 'hsl(var(--muted))' }} />
+                            <Bar dataKey="count" name="Frequency" fill="hsl(var(--primary))" />
+                            <ReferenceLine x={mean} stroke="hsl(var(--destructive))" strokeWidth={2}>
+                                <Label value="Mean" position="top" fill="hsl(var(--destructive))" />
+                            </ReferenceLine>
+                        </BarChart>
+                    </ResponsiveContainer>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+
+export default NormalDistributionSimulation;


### PR DESCRIPTION
## Summary
- implement `NormalDistributionSimulation` for generating samples and histogram
- implement `MetropolisHastingsAlgorithmSimulation` for sampling from a mixture distribution
- wire these simulations into `ConceptSimulationWrapper` via new mapping entries

## Testing
- `npm run lint` *(fails: several lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_684f540c3fe88327b178290a77a07df3