### PR TITLE
Set toast auto-remove delay to 5s

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- adjust toast removal delay to 5 seconds

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fdf6887c48327a320c2f042655363