### PR TITLE
Refine overfitting simulation domain handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ To create a production build run `npm run build` and serve the contents of the `
 ## Known Issues
 
 - **Support Vector Machines (SVM)** – the concept entry uses the ID `support-vector-machines` while the component mapping expected `support-vector-machine`. This mismatch prevented the simulation from loading. The mapping has been fixed, but the simulation may still require further tuning.
-- **Overfitting & Underfitting** – this simulation occasionally renders without any data points. Click **New Data Sample** to regenerate the dataset if this occurs.
 
 ## Original Project URL
 

--- a/src/components/OverfittingUnderfittingSimulation.tsx
+++ b/src/components/OverfittingUnderfittingSimulation.tsx
@@ -97,6 +97,29 @@ const OverfittingUnderfittingSimulation = () => {
         }
         return points;
     }, [fittedFunction]);
+
+    const yDomain = useMemo(() => {
+        const values: number[] = [];
+        if (data.length) {
+            values.push(...data.map((point) => point.y));
+        }
+        if (chartData.length) {
+            values.push(
+                ...chartData.map((point) => point.true),
+                ...chartData.map((point) => point.fitted ?? point.true)
+            );
+        }
+
+        if (values.length === 0) {
+            return [0, 10] as [number, number];
+        }
+
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const padding = Math.max(1, (max - min) * 0.1);
+
+        return [min - padding, max + padding] as [number, number];
+    }, [chartData, data]);
     
     const getModelStatus = () => {
         if(degree < 3) return { text: 'Underfitting', color: 'text-amber-500', Icon: TrendingDown };
@@ -139,10 +162,16 @@ const OverfittingUnderfittingSimulation = () => {
                        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
                             <CartesianGrid />
                             <XAxis type="number" dataKey="x" name="Feature" domain={[0, 10]} />
-                            <YAxis type="number" name="Target" domain={[0, 10]} />
+                            <YAxis type="number" name="Target" domain={yDomain} allowDataOverflow />
                             <Tooltip />
                             <Legend />
-                            <Scatter name="Sample Data" data={data} fill="hsl(var(--primary))" />
+                            <Scatter
+                                name="Sample Data"
+                                data={data}
+                                fill="hsl(var(--primary))"
+                                fillOpacity={0.85}
+                                stroke="hsl(var(--primary))"
+                            />
                             <Line dataKey="true" data={chartData} dot={false} stroke="hsl(var(--secondary))" strokeWidth={2} name="True Function" />
                             <Line dataKey="fitted" data={chartData} dot={false} stroke="hsl(var(--destructive))" strokeWidth={3} name="Fitted Model" />
                        </ScatterChart>


### PR DESCRIPTION
## Summary
- compute the overfitting vs. underfitting chart domain from both sample and fitted series so noise-heavy points remain visible
- adjust scatter styling to keep generated data points visually distinct on the chart

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66c2bb5f8832799c0cd0517d19447